### PR TITLE
C3_OFFSETOF cannot be used in static_assert

### DIFF
--- a/src/server/ht_objects.cc
+++ b/src/server/ht_objects.cc
@@ -301,8 +301,8 @@ c3_uint_t PageObject::po_num_internal_tag_refs = 1;
 PageObject::PageObject(c3_hash_t hash, const char* name, c3_ushort_t nlen):
   PayloadHashObject(hash, HOF_PAYLOAD | HOF_FPC, name, nlen, calculate_size(nlen)) {
 
-  static_assert(C3_OFFSETOF(PageObject, po_xtags) == sizeof(PayloadHashObject),
-    "PageObject::po_tags[] field is not aligned properly");
+  // check if PageObject::po_tags[] field is aligned properly
+  c3_assert(C3_OFFSETOF(PageObject, po_xtags) == sizeof(PayloadHashObject));
 
   PERF_INCREMENT_DOMAIN_COUNTER(FPC, Store_Objects_Created)
   PERF_INCREMENT_DOMAIN_COUNTER(FPC, Store_Objects_Active)

--- a/src/server/pl_pipeline_commands.cc
+++ b/src/server/pl_pipeline_commands.cc
@@ -19,7 +19,7 @@
 namespace CyberCache {
 
 PipelineCommand* PipelineCommand::create(c3_uintptr_t id, domain_t domain, const void* buff, size_t size) {
-  static_assert(C3_OFFSETOF(PipelineCommand, pc_null) == 0, "NULL offset is not zero");
+  c3_assert(C3_OFFSETOF(PipelineCommand, pc_null) == 0); // NULL offset must be zero
   c3_assert(id <= BYTE_MAX_VAL && size <= USHORT_MAX_VAL);
   auto pc = alloc<PipelineCommand>(domain, size + sizeof(PipelineCommand));
   new (pc) PipelineCommand((c3_byte_t) id, domain, (c3_ushort_t) size);


### PR DESCRIPTION
static_assert requires that its argument is a constexpr. C3_OFFSETOF on
the other hand is necessarily implemented using reinterpret_cast which
is forbidden from constexpr in C++14 and later. There is hope that C++20
will make standard offsetof() work in our use cases. Until then our only
option is to use runtime assertions when C3_OFFSETOF is involved.